### PR TITLE
Add the option to do a full database clone instead of prefixed tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ webroot, and merges it into master.
 Then, call the site cloning script, which uses drush to clone an existing
 staging site.
 
-`clone_site.sh` `[-deghHilvx]` `<source-drush-alias>` `<url>`
+`clone_site.sh` `[-deghHilvxc]` `<source-drush-alias>` `<url>`
 
 To clean up afterwards, call cleanup.sh using the same pull request ID and
 location of your webroot.
 
-`cleanup.sh` `[-dhiluvx]`
+`cleanup.sh` `[-dhiluvxc]`
 
 ## What does it do?
 - Moves the checked out repository to a unique directory in the workspace.
@@ -76,6 +76,8 @@ location of your webroot.
   will be at https://www.example.com/foo/234.
 
 ## Options
+* `-c`  Optional. Specifies that the full database is cloned instead of using
+        table prefixes.
 * `-e`  Optional. Extra settings to be concatenated to the settings.php file
         when it is cloned. Only used in clone_site.sh.
 * `-g`  Optional. The http server's group, such as www-data or apache. This is

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -15,8 +15,9 @@ usage() {
 DRUSH="drush"
 WEBROOT=$WORKSPACE
 VERBOSE=""
+CLONE="table"
 
-while getopts “hi:l:d:u:vx” OPTION; do
+while getopts “hi:l:d:u:cvx” OPTION; do
   case $OPTION in
     h)
       usage
@@ -33,6 +34,9 @@ while getopts “hi:l:d:u:vx” OPTION; do
       ;;
     u)
       URIS=$OPTARG
+      ;;
+    c)
+      CLONE="database"
       ;;
     v)
       VERBOSE="--verbose"
@@ -92,7 +96,12 @@ fi
 # Delete all prefixed tables.
 for URI in $URIS; do
   DESTINATION="$DESTINATION --uri=$URI"
-  $DRUSH $DESTINATION --yes drop-prefixed-tables $DB_PREFIX
+  if [ "$CLONE" == "database" ]; then
+    DATABASE=`$DRUSH $DESTINATION status database_name --format=list`
+    $DRUSH $DESTINATION sqlq "DROP DATABASE $DATABASE"
+  else
+    $DRUSH $DESTINATION --yes drop-prefixed-tables $DB_PREFIX
+  fi
 done;
 
 # Remove the symlink.

--- a/jgd.drush.inc
+++ b/jgd.drush.inc
@@ -44,10 +44,11 @@ function jgd_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
     'arguments' => array(
       'site_alias' => dt('Drush site alias of the site to clone from.'),
-      'prefix' => dt('An optional table prefix to add to the database array in the settings.php file.'),
+      'prefix / suffix' => dt('An optional table prefix or database name suffix to add to the database array in the settings.php file.'),
     ),
     'options' => array(
       'extra-settings' => dt('A string of extra settings to be added to the settings.php file.'),
+      'database' => dt('Use a database instead of using tables.'),
     ),
     'required-arguments' => 1,
   );
@@ -196,14 +197,26 @@ function drush_jgd_clone_settings_php($site_alias, $prefix = NULL) {
 
   // If there's a database prefix, attempt to use it.
   if (isset($prefix)) {
-    // Match a new line with spaces and an empty prefix string.
-    $pattern = "%(\n\ *)'prefix' => '',%";
-    // Replace with the following.
-    $replacement = "\${1}'prefix' => '$prefix',";
+    if (drush_get_option('database')) {
+      // Match a new line with spaces and a database option.
+      $pattern = "%(\n\ *)'database' => '([a-zA-Z0-9_]+)',%";
+      // Replace with the following.
+      $replacement = "\${1}'database' => '\${2}$prefix',";
+      // Here's the error message if this fails.
+      $error_message = 'The database name suffix @prefix was not added to settings.php. You will need to do this by hand.';
+    }
+    else {
+      // Match a new line with spaces and an empty prefix string.
+      $pattern = "%(\n\ *)'prefix' => '',%";
+      // Replace with the following.
+      $replacement = "\${1}'prefix' => '$prefix',";
+      // Here's the error message if this fails.
+      $error_message = 'The database table prefix @prefix was not added to settings.php. You will need to do this by hand.';
+    }
     $destination_settings = preg_replace($pattern, $replacement, $source_settings);
     // If nothing changed, log a warning.
     if ($destination_settings == $source_settings) {
-      drush_log(dt('The database table prefix @prefix was not added to settings.php. You will need to do this by hand.'), 'warning');
+      drush_log(dt($error_message), 'warning');
       // Unset the prefix, so the completed message won't say it was added.
       unset($prefix);
     }


### PR DESCRIPTION
The default behavior is still to use table prefixes, since that should work on any Drupal site. In order to use a full database clone, the -c option needs to be sent to clone_site.sh and cleanup.sh
